### PR TITLE
Fix version handling

### DIFF
--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/CliOptions.java
@@ -303,26 +303,24 @@ class CliOptions {
     /**
      * Prints out the Plugin Management Tool version
      */
-    public void showVersion() throws IOException {
+    public void showVersion() {
         try (InputStream propertyInputStream = getPropertiesInputStream("/.properties")) {
             if (propertyInputStream == null) {
-                System.out.println("No version information available");
-                return;
+                throw new VersionNotFoundException("No version information available");
             }
-            final Properties properties = new Properties();
+            Properties properties = new Properties();
             properties.load(propertyInputStream);
-            System.out.println("Version: " + properties.getProperty("project.version"));
+
+            System.out.println(properties.getProperty("project.version"));
         } catch (IOException e) {
-            System.out.println("No version information available");
-            throw new IOException(e);
+            throw new VersionNotFoundException("No version information available", e);
         }
     }
 
+    // visible for testing
     public InputStream getPropertiesInputStream(String path) {
-        InputStream inputStream = this.getClass().getResourceAsStream(path);
-        return inputStream;
+        return this.getClass().getResourceAsStream(path);
     }
-
 
     /**
      * Returns if user requested to see the tool version from the CLI options

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/Main.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/Main.java
@@ -21,18 +21,20 @@ public class Main {
             throw new IOException("Failed to read command-line arguments", e);
         }
 
-
-        if (options.isShowVersion()) {
-            try {
+        try {
+            if (options.isShowVersion()) {
                 options.showVersion();
-            } catch (IOException e) {
-                System.exit(1);
+                return;
             }
-        }
 
-        Config cfg = options.setup();
-        PluginManager pm = new PluginManager(cfg);
-        pm.start();
+            Config cfg = options.setup();
+            PluginManager pm = new PluginManager(cfg);
+            pm.start();
+        } catch (Exception e) {
+            // TODO add stacktrace during verbose mode
+            System.err.println(e.getMessage());
+            System.exit(1);
+        }
 
     }
 

--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/VersionNotFoundException.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/VersionNotFoundException.java
@@ -1,0 +1,12 @@
+package io.jenkins.tools.pluginmanager.cli;
+
+public class VersionNotFoundException extends RuntimeException {
+
+    public VersionNotFoundException(String message) {
+        super(message);
+    }
+
+    public VersionNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
+++ b/plugin-management-cli/src/test/java/io/jenkins/tools/pluginmanager/cli/CliOptionsTest.java
@@ -5,7 +5,6 @@ import io.jenkins.tools.pluginmanager.config.Settings;
 import io.jenkins.tools.pluginmanager.impl.Plugin;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URISyntaxException;
@@ -26,14 +25,13 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 import static org.mockito.Mockito.when;
-
 
 
 @RunWith(PowerMockRunner.class)
@@ -244,27 +242,25 @@ public class CliOptionsTest {
         when(properties.getProperty(any(String.class))).thenReturn(version);
 
         options.showVersion();
-        assertEquals("Version: " + version +"\n", outContent.toString());
+        assertEquals(version +"\n", outContent.toString());
 
         ByteArrayOutputStream aliasVersionOut = new ByteArrayOutputStream();
         System.setOut(new PrintStream(aliasVersionOut));
 
         parser.parseArgument("-v");
         options.showVersion();
-        assertEquals("Version: " + version +"\n", outContent.toString());
+        assertEquals(version +"\n", outContent.toString());
     }
 
 
-    @Test
-    public void showVersionErrorTest() throws CmdLineException, FileNotFoundException {
+    @Test(expected = VersionNotFoundException.class)
+    public void showVersionErrorTest() throws CmdLineException {
         ByteArrayOutputStream nullPropertiesOut = new ByteArrayOutputStream();
         System.setOut(new PrintStream(nullPropertiesOut));
         CliOptions cliOptionsSpy = spy(options);
         parser.parseArgument("--version");
         doReturn(null).when(cliOptionsSpy).getPropertiesInputStream(any(String.class));
         cliOptionsSpy.showVersion();
-
-        assertEquals("No version information available\n", nullPropertiesOut.toString());
     }
 
     @After


### PR DESCRIPTION
I've fixed it up so that -v exits correctly and if there's an unhandled exception it'll get nicely logged and exit properly, in your verbose PR we should add the stacktrace to the the try catch I added

@kwhetstone @stopalopa  